### PR TITLE
Use require_dependency instead of require to depend on query.rb

### DIFF
--- a/lib/query_column.rb
+++ b/lib/query_column.rb
@@ -1,4 +1,4 @@
-require 'query'
+require_dependency 'query'
 
 class VOI_QueryColumn < QueryColumn
 =begin


### PR DESCRIPTION
We shouldn't use require as it is directly including class causing duplicate
constants etc.